### PR TITLE
use .openapi-generator-ignore in python client generation

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -20,19 +20,8 @@ gen-python-urllib3-client: clean-python-urllib3-client
 	  -i ../spec/rest.yaml \
 	  -g python \
 	  -o lance_namespace_urllib3_client \
-	  --additional-properties=packageName=lance_namespace_urllib3_client,packageVersion=$(VERSION),library=urllib3
-  	# TODO: using .openapi-generator-ignore was not working, manually delete unused files for now
-	rm -rf lance_namespace_urllib3_client/.github
-	rm -rf lance_namespace_urllib3_client/.gitignore
-	rm -rf lance_namespace_urllib3_client/.gitlab-ci.yml
-	rm -rf lance_namespace_urllib3_client/.travis.yml
-	rm -rf lance_namespace_urllib3_client/git_push.sh
-	rm -rf lance_namespace_urllib3_client/requirements.txt
-	rm -rf lance_namespace_urllib3_client/setup.cfg
-	rm -rf lance_namespace_urllib3_client/setup.py
-	rm -rf lance_namespace_urllib3_client/test-requirements.txt
-	rm -rf lance_namespace_urllib3_client/tox.ini
-	rm -rf lance_namespace_urllib3_client/.openapi-generator-ignore
+	  --additional-properties=packageName=lance_namespace_urllib3_client,packageVersion=$(VERSION),library=urllib3 \
+	# Clean up OpenAPI Generator metadata after generation
 	rm -rf lance_namespace_urllib3_client/.openapi-generator
 
 build-python-urllib3-client: gen-python-urllib3-client

--- a/python/lance_namespace_urllib3_client/.openapi-generator-ignore
+++ b/python/lance_namespace_urllib3_client/.openapi-generator-ignore
@@ -1,0 +1,11 @@
+.github
+.gitignore
+.gitlab-ci.yml
+.travis.yml
+git_push.sh
+requirements.txt
+setup.cfg
+setup.py
+test-requirements.txt
+tox.ini
+/.github/workflows/python.yml


### PR DESCRIPTION
This PR uses the `.openapi-generator-ignore` file for the Python client generation, instead of running manual `rm` commands afterwards. The OpenAPI generator for the Python client requires the ignore file to be in the output directory.

However, the generation metadata `.openapi-generator/` is something that can't be skipped in the python client generation, but there are some open PRs to address this across all clients which seem to have been open for a while now. For example: https://github.com/OpenAPITools/openapi-generator/pull/15770.

I see that the repo is also cleaning `.openapi-generator-ignore` files so feel free to close this if not needed.

### Testing 

`make clean-python && make gen-python`
