### PR TITLE
chore: add support for OpenAPI spec validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,6 @@ build-java:
 
 clean: clean-rust clean-python clean-java
 
-gen: gen-rust gen-python gen-java
+gen: lint gen-rust gen-python gen-java
 
 build: build-rust build-python build-java

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+lint:
+	openapi-spec-validator --errors all spec/rest.yaml
+
 clean-rust:
 	cd rust; make clean
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ To quickly install it in your virtual environment:
 pip install -r python/requirements.txt
 ```
 
+### Lint
+To ensure the OpenAPI definition is valid, you can use the lint command to check it.
+
+```bash
+make lint
+```
+
 ### Build
 
 There are 3 commands that is available at top level as well as inside each language folder:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+openapi-spec-validator==0.7.1
 openapi-generator-cli==7.12.0


### PR DESCRIPTION
This PR adds OpenAPI spec validation using `openapi-spec-validator`. This will allow for spec validation when making changes to the REST spec and ensures the spec is error-free before generating any client logic.

### Testing
`make lint`