### PR TITLE
feat: add glue listNamespaces support

### DIFF
--- a/java/lance-namespace-glue/pom.xml
+++ b/java/lance-namespace-glue/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>com.lancedb</groupId>
+      <artifactId>lance-namespace-root</artifactId>
+      <version>0.0.1</version>
+      <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>lance-namespace-glue</artifactId>
+    <name>${project.artifactId}</name>
+    <description>Lance Namespace AWS Glue Impl</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <aws.sdk.version>2.32.2</aws.sdk.version>
+    </properties>
+
+    <dependencies>
+      <dependency>
+        <groupId>com.lancedb</groupId>
+        <artifactId>lance-namespace-core</artifactId>
+        <version>${lance-namespace.version}</version>
+      </dependency>
+      
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>glue</artifactId>
+        <version>${aws.sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>auth</artifactId>
+        <version>${aws.sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>regions</artifactId>
+        <version>${aws.sdk.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.17</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>5.18.0</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+</project>

--- a/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/GlueProperties.java
+++ b/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/GlueProperties.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.namespace;
+
+import com.google.common.base.Strings;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Map;
+
+public class GlueProperties implements Serializable {
+
+  /**
+   * The Catalog ID of the Glue catalog to be used for all operations. If not specified, Glue
+   * defaults to the AWS account ID of the caller.
+   *
+   * <p>For more details, see
+   * https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-catalog-databases.html
+   */
+  public static final String CATALOG_ID = "glue.id";
+
+  /**
+   * Configures a specific Glue service endpoint for the GlueCatalog.
+   *
+   * <p>This allows GlueCatalog to connect to any Glue API compatible metastore with a custom
+   * endpoint.
+   */
+  public static final String ENDPOINT = "glue.endpoint";
+
+  /** Configure the AWS region for all Glue operations */
+  public static final String REGION = "glue.region";
+
+  /**
+   * AWS access key ID for static credentials.
+   *
+   * <p>If set along with {@link #SECRET_ACCESS_KEY}, the client uses these credentials instead of
+   * the default AWS credential provider chain. If {@link #SESSION_TOKEN} is also provided, session
+   * credentials will be used.
+   */
+  public static final String ACCESS_KEY_ID = "glue.access-key-id";
+
+  /**
+   * AWS secret access key for static credentials.
+   *
+   * <p>Used together with {@link #ACCESS_KEY_ID}. If {@link #SESSION_TOKEN} is provided, session
+   * credentials are used; otherwise, basic credentials are used.
+   */
+  public static final String SECRET_ACCESS_KEY = "glue.secret-access-key";
+
+  /**
+   * AWS session token for temporary credentials.
+   *
+   * <p>When set, the glue client uses session credentials rather than the default credential
+   * provider chain.
+   */
+  public static final String SESSION_TOKEN = "glue.session-token";
+
+  private final String glueEndpoint;
+  private final String glueRegion;
+  private final String glueCatalogId;
+  private final String glueAccessKeyId;
+  private final String glueSecretAccessKey;
+  private final String glueSessionToken;
+
+  public GlueProperties() {
+    this.glueCatalogId = null;
+    this.glueEndpoint = null;
+    this.glueRegion = null;
+    this.glueAccessKeyId = null;
+    this.glueSecretAccessKey = null;
+    this.glueSessionToken = null;
+  }
+
+  public GlueProperties(Map<String, String> properties) {
+    this.glueEndpoint = properties.get(ENDPOINT);
+    this.glueRegion = properties.get(REGION);
+    this.glueCatalogId = properties.get(CATALOG_ID);
+    this.glueAccessKeyId = properties.get(ACCESS_KEY_ID);
+    this.glueSecretAccessKey = properties.get(SECRET_ACCESS_KEY);
+    this.glueSessionToken = properties.get(SESSION_TOKEN);
+  }
+
+  public String glueCatalogId() {
+    return glueCatalogId;
+  }
+
+  private AwsCredentialsProvider credentialsProvider() {
+    if (!Strings.isNullOrEmpty(glueAccessKeyId) && !Strings.isNullOrEmpty(glueSecretAccessKey)) {
+      return StaticCredentialsProvider.create(
+          Strings.isNullOrEmpty(glueSessionToken)
+              ? AwsBasicCredentials.create(glueAccessKeyId, glueSecretAccessKey)
+              : AwsSessionCredentials.create(
+                  glueAccessKeyId, glueSecretAccessKey, glueSessionToken));
+    }
+    return DefaultCredentialsProvider.builder().build();
+  }
+
+  public void configureClientBuilder(GlueClientBuilder builder) {
+    if (glueEndpoint != null) {
+      builder.endpointOverride(URI.create(glueEndpoint));
+    }
+    Region region =
+        Strings.isNullOrEmpty(glueRegion)
+            ? DefaultAwsRegionProviderChain.builder().build().getRegion()
+            : Region.of(glueRegion);
+    builder.region(region);
+    builder.credentialsProvider(credentialsProvider());
+  }
+}

--- a/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/LanceGlueNamespace.java
+++ b/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/LanceGlueNamespace.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.namespace.glue;
+
+import com.lancedb.lance.namespace.GlueProperties;
+import com.lancedb.lance.namespace.LanceNamespace;
+import com.lancedb.lance.namespace.model.AlterTransactionRequest;
+import com.lancedb.lance.namespace.model.AlterTransactionResponse;
+import com.lancedb.lance.namespace.model.CountRowsRequest;
+import com.lancedb.lance.namespace.model.CreateIndexRequest;
+import com.lancedb.lance.namespace.model.CreateIndexResponse;
+import com.lancedb.lance.namespace.model.CreateNamespaceRequest;
+import com.lancedb.lance.namespace.model.CreateNamespaceResponse;
+import com.lancedb.lance.namespace.model.CreateTableResponse;
+import com.lancedb.lance.namespace.model.DeleteFromTableRequest;
+import com.lancedb.lance.namespace.model.DeleteFromTableResponse;
+import com.lancedb.lance.namespace.model.DeregisterTableRequest;
+import com.lancedb.lance.namespace.model.DeregisterTableResponse;
+import com.lancedb.lance.namespace.model.DescribeNamespaceRequest;
+import com.lancedb.lance.namespace.model.DescribeNamespaceResponse;
+import com.lancedb.lance.namespace.model.DescribeTableRequest;
+import com.lancedb.lance.namespace.model.DescribeTableResponse;
+import com.lancedb.lance.namespace.model.DescribeTransactionRequest;
+import com.lancedb.lance.namespace.model.DescribeTransactionResponse;
+import com.lancedb.lance.namespace.model.DropNamespaceRequest;
+import com.lancedb.lance.namespace.model.DropNamespaceResponse;
+import com.lancedb.lance.namespace.model.DropTableRequest;
+import com.lancedb.lance.namespace.model.DropTableResponse;
+import com.lancedb.lance.namespace.model.IndexListRequest;
+import com.lancedb.lance.namespace.model.IndexListResponse;
+import com.lancedb.lance.namespace.model.IndexStatsRequest;
+import com.lancedb.lance.namespace.model.IndexStatsResponse;
+import com.lancedb.lance.namespace.model.InsertTableResponse;
+import com.lancedb.lance.namespace.model.ListNamespacesRequest;
+import com.lancedb.lance.namespace.model.ListNamespacesResponse;
+import com.lancedb.lance.namespace.model.MergeInsertTableRequest;
+import com.lancedb.lance.namespace.model.MergeInsertTableResponse;
+import com.lancedb.lance.namespace.model.NamespaceExistsRequest;
+import com.lancedb.lance.namespace.model.NamespaceExistsResponse;
+import com.lancedb.lance.namespace.model.QueryRequest;
+import com.lancedb.lance.namespace.model.RegisterTableRequest;
+import com.lancedb.lance.namespace.model.RegisterTableResponse;
+import com.lancedb.lance.namespace.model.TableExistsRequest;
+import com.lancedb.lance.namespace.model.TableExistsResponse;
+import com.lancedb.lance.namespace.model.UpdateTableRequest;
+import com.lancedb.lance.namespace.model.UpdateTableResponse;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesResponse;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class LanceGlueNamespace implements LanceNamespace, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(LanceGlueNamespace.class);
+  private static final int MAX_GLUE_LISTING_SIZE = 100;
+
+  private GlueProperties properties;
+  public GlueClient glueClient;
+  private String name;
+
+  public LanceGlueNamespace() {}
+
+  @Override
+  public void initialize(String name, Map<String, String> properties) {
+    GlueProperties glueProperties = new GlueProperties(properties);
+    GlueClient glueClient =
+        GlueClient.builder().applyMutation(glueProperties::configureClientBuilder).build();
+    initialize(name, glueProperties, glueClient);
+  }
+
+  @VisibleForTesting
+  void initialize(String name, GlueProperties properties, GlueClient glueClient) {
+    this.properties = properties;
+    this.glueClient = glueClient;
+    this.name = name;
+  }
+
+  @Override
+  public ListNamespacesResponse listNamespaces(ListNamespacesRequest request) {
+    validateSingleLevelNamespace(request.getParent());
+
+    GetDatabasesRequest.Builder listRequest =
+        GetDatabasesRequest.builder().catalogId(properties.glueCatalogId());
+    int pageSize = request.getPageSize() != null ? request.getPageSize() : Integer.MAX_VALUE;
+    int remaining = pageSize;
+    String glueNextToken = request.getPageToken();
+    Set<String> databases = Sets.newHashSet();
+    do {
+      int fetchSize = Math.min(remaining, MAX_GLUE_LISTING_SIZE);
+      GetDatabasesResponse response =
+          glueClient.getDatabases(
+              listRequest.maxResults(fetchSize).nextToken(glueNextToken).build());
+      response.databaseList().forEach(d -> databases.add(d.name()));
+      glueNextToken = response.nextToken();
+      remaining = pageSize - databases.size();
+    } while (glueNextToken != null && remaining > 0);
+
+    LOG.debug("Listing namespace returned : {}", String.join(", ", databases));
+    return new ListNamespacesResponse().namespaces(databases).nextPageToken(glueNextToken);
+  }
+
+  @Override
+  public DescribeNamespaceResponse describeNamespace(DescribeNamespaceRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DropNamespaceResponse dropNamespace(DropNamespaceRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DescribeTableResponse describeTable(DescribeTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public Long countRows(CountRowsRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public CreateTableResponse createTable(String tableName, byte[] arrowIpcData) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public InsertTableResponse insertTable(String tableName, byte[] arrowIpcData, String mode) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public MergeInsertTableResponse mergeInsertTable(
+      MergeInsertTableRequest request,
+      byte[] arrowIpcData,
+      String on,
+      Boolean whenMatchedUpdateAll,
+      Boolean whenNotMatchedInsertAll) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public UpdateTableResponse updateTable(UpdateTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DeleteFromTableResponse deleteFromTable(DeleteFromTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public byte[] queryTable(QueryRequest request) {
+    return new byte[0];
+  }
+
+  @Override
+  public CreateIndexResponse createIndex(CreateIndexRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public CreateIndexResponse createScalarIndex(CreateIndexRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public IndexListResponse listIndices(IndexListRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public IndexStatsResponse getIndexStats(IndexStatsRequest request, String indexName) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public RegisterTableResponse registerTable(RegisterTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public TableExistsResponse tableExists(TableExistsRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DropTableResponse dropTable(DropTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DeregisterTableResponse deregisterTable(DeregisterTableRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public DescribeTransactionResponse describeTransaction(DescribeTransactionRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  @Override
+  public AlterTransactionResponse alterTransaction(AlterTransactionRequest request) {
+    throw new UnsupportedOperationException("Not supported");
+  }
+
+  private void validateSingleLevelNamespace(List<String> parent) {
+    if (parent != null && !parent.isEmpty()) {
+      throw new RuntimeException("Glue does not support nested namespace, found nested: " + parent);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (glueClient != null) {
+      glueClient.close();
+    }
+  }
+}

--- a/java/lance-namespace-glue/src/test/java/com/lancedb/lance/namespace/TestGlueProperties.java
+++ b/java/lance-namespace-glue/src/test/java/com/lancedb/lance/namespace/TestGlueProperties.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.namespace;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.glue.GlueClientBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.verify;
+
+public class TestGlueProperties {
+
+  @Test
+  public void testDefaultCredentials() {
+    GlueProperties properties = new GlueProperties();
+    GlueClientBuilder mockBuilder = mockGlueClientBuilder();
+
+    properties.configureClientBuilder(mockBuilder);
+
+    ArgumentCaptor<AwsCredentialsProvider> credsCaptor =
+        ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+    verify(mockBuilder).credentialsProvider(credsCaptor.capture());
+    assertInstanceOf(DefaultCredentialsProvider.class, credsCaptor.getValue());
+  }
+
+  @Test
+  public void testPropertiesFromMap() {
+    Map<String, String> props =
+        Map.of(
+            GlueProperties.CATALOG_ID, "1234567890",
+            GlueProperties.REGION, "us-west-2",
+            GlueProperties.ENDPOINT, "https://glue.us-west-2.api.aws");
+    GlueProperties properties = new GlueProperties(props);
+    assertEquals("1234567890", properties.glueCatalogId());
+  }
+
+  @Test
+  public void testBasicCredentials() {
+    Map<String, String> props =
+        Map.of(
+            GlueProperties.ACCESS_KEY_ID, "mykey",
+            GlueProperties.SECRET_ACCESS_KEY, "secret");
+
+    GlueProperties properties = new GlueProperties(props);
+    GlueClientBuilder mockBuilder = mockGlueClientBuilder();
+    properties.configureClientBuilder(mockBuilder);
+
+    ArgumentCaptor<AwsCredentialsProvider> credsCaptor =
+        ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+    verify(mockBuilder).credentialsProvider(credsCaptor.capture());
+
+    AwsCredentialsProvider provider = credsCaptor.getValue();
+    assertInstanceOf(AwsBasicCredentials.class, provider.resolveCredentials());
+    AwsBasicCredentials creds = (AwsBasicCredentials) provider.resolveCredentials();
+    assertEquals("mykey", creds.accessKeyId());
+    assertEquals("secret", creds.secretAccessKey());
+  }
+
+  @Test
+  public void testSessionCredentials() {
+    Map<String, String> props =
+        Map.of(
+            GlueProperties.ACCESS_KEY_ID, "mykey",
+            GlueProperties.SECRET_ACCESS_KEY, "secret",
+            GlueProperties.SESSION_TOKEN, "token");
+
+    GlueProperties properties = new GlueProperties(props);
+    GlueClientBuilder mockBuilder = mockGlueClientBuilder();
+    properties.configureClientBuilder(mockBuilder);
+
+    ArgumentCaptor<AwsCredentialsProvider> credsCaptor =
+        ArgumentCaptor.forClass(AwsCredentialsProvider.class);
+    verify(mockBuilder).credentialsProvider(credsCaptor.capture());
+
+    AwsCredentialsProvider provider = credsCaptor.getValue();
+    assertInstanceOf(AwsSessionCredentials.class, provider.resolveCredentials());
+    AwsSessionCredentials creds = (AwsSessionCredentials) provider.resolveCredentials();
+    assertEquals("mykey", creds.accessKeyId());
+    assertEquals("secret", creds.secretAccessKey());
+    assertEquals("token", creds.sessionToken());
+  }
+
+  @Test
+  public void testConfigureGlueClientBuilder() {
+    Map<String, String> props =
+        Map.of(
+            GlueProperties.CATALOG_ID, "1234567890",
+            GlueProperties.REGION, "us-west-2",
+            GlueProperties.ENDPOINT, "https://glue.us-west-2.api.aws",
+            GlueProperties.ACCESS_KEY_ID, "mykey",
+            GlueProperties.SECRET_ACCESS_KEY, "secret");
+
+    GlueProperties properties = new GlueProperties(props);
+    GlueClientBuilder mockBuilder = mockGlueClientBuilder();
+    properties.configureClientBuilder(mockBuilder);
+
+    ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+    verify(mockBuilder).region(regionCaptor.capture());
+    assertEquals("us-west-2", regionCaptor.getValue().toString());
+
+    ArgumentCaptor<URI> endpointCaptor = ArgumentCaptor.forClass(URI.class);
+    verify(mockBuilder).endpointOverride(endpointCaptor.capture());
+    assertEquals("https://glue.us-west-2.api.aws", endpointCaptor.getValue().toString());
+  }
+
+  private GlueClientBuilder mockGlueClientBuilder() {
+    GlueClientBuilder mockBuilder = Mockito.mock(GlueClientBuilder.class);
+    Mockito.when(mockBuilder.region(Mockito.any(Region.class))).thenReturn(mockBuilder);
+    Mockito.when(mockBuilder.endpointOverride(Mockito.any(URI.class))).thenReturn(mockBuilder);
+    Mockito.when(mockBuilder.credentialsProvider(Mockito.any(AwsCredentialsProvider.class)))
+        .thenReturn(mockBuilder);
+    return mockBuilder;
+  }
+}

--- a/java/lance-namespace-glue/src/test/java/com/lancedb/lance/namespace/glue/TestLanceGlueNamespace.java
+++ b/java/lance-namespace-glue/src/test/java/com/lancedb/lance/namespace/glue/TestLanceGlueNamespace.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.namespace.glue;
+
+import com.lancedb.lance.namespace.GlueProperties;
+import com.lancedb.lance.namespace.model.ListNamespacesRequest;
+import com.lancedb.lance.namespace.model.ListNamespacesResponse;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.Database;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class TestLanceGlueNamespace {
+
+  @Mock private GlueClient glue;
+
+  private LanceGlueNamespace glueNamespace;
+
+  @BeforeEach
+  public void before() {
+    this.glueNamespace = new LanceGlueNamespace();
+    GlueProperties glueProperties = new GlueProperties();
+    glueNamespace.initialize("glue", glueProperties, glue);
+  }
+
+  @Test
+  public void testBasicListNamespaces() {
+    when(glue.getDatabases(any(GetDatabasesRequest.class)))
+        .thenReturn(
+            GetDatabasesResponse.builder()
+                .databaseList(
+                    Database.builder().name("db1").build(), Database.builder().name("db2").build())
+                .build());
+
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    ListNamespacesResponse response = glueNamespace.listNamespaces(request);
+
+    assertNotNull(response.getNamespaces());
+    assertEquals(2, response.getNamespaces().size());
+    assertEquals(Sets.newHashSet("db1", "db2"), response.getNamespaces());
+    assertNull(response.getNextPageToken());
+  }
+
+  @Test
+  void testListingAllPagination() {
+    GetDatabasesResponse respOne =
+        GetDatabasesResponse.builder()
+            .databaseList(
+                Database.builder().name("db1").build(), Database.builder().name("db2").build())
+            .nextToken("tkn1")
+            .build();
+
+    GetDatabasesResponse respTwo =
+        GetDatabasesResponse.builder()
+            .databaseList(Database.builder().name("db3").build())
+            .nextToken(null)
+            .build();
+
+    when(glue.getDatabases(any(GetDatabasesRequest.class))).thenReturn(respOne, respTwo);
+
+    ListNamespacesResponse resp = glueNamespace.listNamespaces(new ListNamespacesRequest());
+    assertEquals(Sets.newHashSet("db1", "db2", "db3"), resp.getNamespaces());
+    assertNull(resp.getNextPageToken());
+  }
+
+  @Test
+  void testEmptyListNamespaces() {
+    when(glue.getDatabases(any(GetDatabasesRequest.class)))
+        .thenReturn(GetDatabasesResponse.builder().build());
+
+    ListNamespacesRequest request = new ListNamespacesRequest();
+    ListNamespacesResponse response = glueNamespace.listNamespaces(request);
+
+    assertNotNull(response.getNamespaces());
+    assertEquals(0, response.getNamespaces().size());
+    assertNull(response.getNextPageToken());
+  }
+
+  @Test
+  void testNestedParentThrows() {
+    ListNamespacesRequest req = new ListNamespacesRequest().parent(Lists.newArrayList("a", "b"));
+    assertThrows(RuntimeException.class, () -> glueNamespace.listNamespaces(req));
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -91,6 +91,7 @@
         <module>lance-namespace-core</module>
         <module>lance-namespace-adapter</module>
         <module>lance-namespace-hive</module>
+        <module>lance-namespace-glue</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR lays the initial groundwork for Lance namespace support in AWS Glue Catalog, starting with `ListNamespaces`.

In this approach, to support pagination correctly, I had to align Lance’s models to Glue’s bounds and restrictions. For example, Lance places no explicit bounds on pageSize, while Glue enforces a maximum of 100 results per call. 
So I just fetches results from Glue in batches, continuing until either the requested page size is met or Glue has no more results.

Also, started the ground work for AWS clients by adding support for Static credentials, and fall back to default AWS credential provider chain.

## Testing
- manual testing
- `./mvnw clean install`