### PR TITLE
chore: run java-lancedb when the module is edited

### DIFF
--- a/.github/workflows/java-lancedb.yml
+++ b/.github/workflows/java-lancedb.yml
@@ -16,9 +16,14 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
     paths:
-      - docs/src/spec/**
-      - java/**
+      - java/lance-namespace-lancedb/**
       - .github/workflows/java-lancedb.yml
   workflow_dispatch:
     inputs:
@@ -45,7 +50,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache


### PR DESCRIPTION
This requires the user to set lancedb credentials in the fork. But if the user is editing those components, they should have.