### PR TITLE
feat: Implement Glue namespace table operations

### DIFF
--- a/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/GlueNamespaceConfig.java
+++ b/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/GlueNamespaceConfig.java
@@ -13,7 +13,10 @@
  */
 package com.lancedb.lance.namespace.glue;
 
+import com.lancedb.lance.namespace.util.PropertyUtil;
+
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -73,12 +76,15 @@ public class GlueNamespaceConfig implements Serializable {
    */
   public static final String SESSION_TOKEN = "aws.session-token";
 
+  public static final String STORAGE_OPTIONS_PREFIX = "storage.";
+
   private final String glueEndpoint;
   private final String glueRegion;
   private final String glueCatalogId;
   private final String glueAccessKeyId;
   private final String glueSecretAccessKey;
   private final String glueSessionToken;
+  private final Map<String, String> storageOptions;
 
   public GlueNamespaceConfig() {
     this.glueCatalogId = null;
@@ -87,6 +93,7 @@ public class GlueNamespaceConfig implements Serializable {
     this.glueAccessKeyId = null;
     this.glueSecretAccessKey = null;
     this.glueSessionToken = null;
+    this.storageOptions = ImmutableMap.of();
   }
 
   public GlueNamespaceConfig(Map<String, String> properties) {
@@ -96,6 +103,7 @@ public class GlueNamespaceConfig implements Serializable {
     this.glueAccessKeyId = properties.get(ACCESS_KEY_ID);
     this.glueSecretAccessKey = properties.get(SECRET_ACCESS_KEY);
     this.glueSessionToken = properties.get(SESSION_TOKEN);
+    this.storageOptions = PropertyUtil.propertiesWithPrefix(properties, STORAGE_OPTIONS_PREFIX);
   }
 
   public String glueCatalogId() {
@@ -121,5 +129,9 @@ public class GlueNamespaceConfig implements Serializable {
       builder.region(Region.of(glueRegion));
     }
     builder.credentialsProvider(credentialsProvider());
+  }
+
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
   }
 }

--- a/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/GlueToLanceErrorConverter.java
+++ b/java/lance-namespace-glue/src/main/java/com/lancedb/lance/namespace/glue/GlueToLanceErrorConverter.java
@@ -15,16 +15,13 @@ package com.lancedb.lance.namespace.glue;
 
 import com.lancedb.lance.namespace.LanceNamespaceException;
 
-import software.amazon.awssdk.services.glue.model.AlreadyExistsException;
-import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
 import software.amazon.awssdk.services.glue.model.GlueException;
 
 public class GlueToLanceErrorConverter {
 
   private GlueToLanceErrorConverter() {}
 
-  public static LanceNamespaceException notFound(
-      EntityNotFoundException e, String message, Object... args) {
+  public static LanceNamespaceException notFound(GlueException e, String message, Object... args) {
     return LanceNamespaceException.notFound(
         String.format(message, args),
         e.getMessage().getClass().getSimpleName(),
@@ -32,8 +29,7 @@ public class GlueToLanceErrorConverter {
         e.getMessage());
   }
 
-  public static LanceNamespaceException conflict(
-      AlreadyExistsException e, String message, Object... args) {
+  public static LanceNamespaceException conflict(GlueException e, String message, Object... args) {
     return LanceNamespaceException.notFound(
         String.format(message, args),
         e.getMessage().getClass().getSimpleName(),


### PR DESCRIPTION
Closes #163 
Closes #162 

This change implements the remaining core core glue namespace logic for table operations, enabling the basic namespace functionality to be done.

- Added a fix to respect the mode in register table
- Clean up all table data in cascade
- `CreateTable` creates a lance data set and registers the table into Glue
- `DropTable` removes table data and drops from Glue
- Version support for describeTable
-  Added storage options support in config that is used for create and drop table

