### PR TITLE
feat: move to Spring Boot 3

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: SONATYPE_USER
           server-password: SONATYPE_TOKEN

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 17 ]
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
           cache: "maven"
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/java/Makefile
+++ b/java/Makefile
@@ -48,7 +48,7 @@ gen-springboot-server: clean-springboot-server
 	  -i ../docs/src/rest.yaml \
 	  -g spring \
       -o lance-namespace-springboot-server \
-      --additional-properties=groupId=com.lancedb,artifactId=lance-namespace-springboot-server,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-namespace-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=spring-boot,interfaceOnly=true,useOptional=true,openApiNullable=false,java8=true,apiPackage=com.lancedb.lance.namespace.server.springboot.api,modelPackage=com.lancedb.lance.namespace.server.springboot.model,useTags=true,skipDefaultInterface=false,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt
+      --additional-properties=groupId=com.lancedb,artifactId=lance-namespace-springboot-server,artifactVersion=$(VERSION),parentGroupId=com.lancedb,parentArtifactId=lance-namespace-root,parentVersion=$(VERSION),parentRelativePath=pom.xml,library=spring-boot,interfaceOnly=true,useOptional=true,openApiNullable=false,java8=true,apiPackage=com.lancedb.lance.namespace.server.springboot.api,modelPackage=com.lancedb.lance.namespace.server.springboot.model,useTags=true,skipDefaultInterface=false,hideGenerationTimestamp=true,licenseName=Apache-2.0,licenseUrl=https://www.apache.org/licenses/LICENSE-2.0.txt,useSpringBoot3=true
 	rm -rf lance-namespace-springboot-server/.openapi-generator-ignore
 	rm -rf lance-namespace-springboot-server/.openapi-generator
 	rm -rf lance-namespace-springboot-server/pom.xml

--- a/java/lance-namespace-adapter/pom.xml
+++ b/java/lance-namespace-adapter/pom.xml
@@ -17,6 +17,10 @@
     <description>Lance Namespace server adapter</description>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.lancedb</groupId>

--- a/java/lance-namespace-adapter/src/test/java/com/lancedb/lance/namespace/adapter/MockExceptionController.java
+++ b/java/lance-namespace-adapter/src/test/java/com/lancedb/lance/namespace/adapter/MockExceptionController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class MockExceptionController {
   @GetMapping("/testNotFound")
-  public String testNotFound(@RequestParam(required = false) String param) {
+  public String testNotFound(@RequestParam(name = "param", required = false) String param) {
     String error = "Mock resource not found";
     String type = "Not found Error";
     String instance = "/v1/namespaces";
@@ -32,7 +32,8 @@ public class MockExceptionController {
 
   @GetMapping("/testInternalError")
   public String transformIntoErrorResponse(
-      @RequestParam(required = false) String param, @RequestParam(required = false) int errorCode) {
+      @RequestParam(name = "param", required = false) String param,
+      @RequestParam(name = "errorCode", required = false) int errorCode) {
     String detail = String.format("%s not found", param);
     throw new LanceNamespaceException(errorCode, detail);
   }

--- a/java/lance-namespace-hive3/pom.xml
+++ b/java/lance-namespace-hive3/pom.xml
@@ -72,6 +72,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <version>10.14.2.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>
         <version>5.11.3</version>

--- a/java/lance-namespace-springboot-server/pom.xml
+++ b/java/lance-namespace-springboot-server/pom.xml
@@ -6,12 +6,9 @@
     <name>lance-namespace-springboot-server</name>
     <version>0.0.8</version>
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <springdoc.version>1.6.14</springdoc.version>
-        <swagger-ui.version>5.3.1</swagger-ui.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <springdoc.version>2.6.0</springdoc.version>
+        <swagger-ui.version>5.17.14</swagger-ui.version>
     </properties>
     <parent>
         <groupId>com.lancedb</groupId>
@@ -33,7 +30,7 @@
           <!--SpringDoc dependencies -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
         <!-- @Nullable annotation -->

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/ApiUtil.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/ApiUtil.java
@@ -13,9 +13,8 @@
  */
 package com.lancedb.lance.namespace.server.springboot.api;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.context.request.NativeWebRequest;
-
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/NamespaceApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/NamespaceApi.java
@@ -31,16 +31,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 
 import java.util.Optional;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/TableApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/TableApi.java
@@ -70,16 +70,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 
 import java.util.Optional;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/TransactionApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/api/TransactionApi.java
@@ -26,16 +26,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 
 import java.util.Optional;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAddColumnsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAddColumnsResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAlterColumnsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableAlterColumnsResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableDropColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableDropColumnsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableDropColumnsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTableDropColumnsResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionAction.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionAction.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionSetProperty.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionSetProperty.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionSetStatus.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionSetStatus.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionUnsetProperty.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AlterTransactionUnsetProperty.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AnalyzeTableQueryPlanRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AnalyzeTableQueryPlanRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AnalyzeTableQueryPlanResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/AnalyzeTableQueryPlanResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/BooleanQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/BooleanQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/BoostQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/BoostQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ColumnAlteration.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ColumnAlteration.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CountTableRowsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CountTableRowsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateNamespaceRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateNamespaceRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateNamespaceResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateNamespaceResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableIndexRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableIndexRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableIndexResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableIndexResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableTagRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/CreateTableTagRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteFromTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteFromTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteFromTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteFromTableResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteTableTagRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeleteTableTagRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeregisterTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeregisterTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeregisterTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DeregisterTableResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeNamespaceRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeNamespaceRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeNamespaceResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeNamespaceResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableIndexStatsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableIndexStatsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableIndexStatsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableIndexStatsResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTableResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTransactionRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTransactionRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTransactionResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DescribeTransactionResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropNamespaceRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropNamespaceRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropNamespaceResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropNamespaceResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableIndexRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableIndexRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableIndexResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableIndexResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/DropTableResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ErrorResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ErrorResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ExplainTableQueryPlanRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ExplainTableQueryPlanRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ExplainTableQueryPlanResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ExplainTableQueryPlanResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/FtsQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/FtsQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableStatsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableStatsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableStatsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableStatsResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableTagVersionRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableTagVersionRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableTagVersionResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/GetTableTagVersionResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/IndexContent.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/IndexContent.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/InsertIntoTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/InsertIntoTableRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/InsertIntoTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/InsertIntoTableResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowDataType.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowDataType.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowField.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowField.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowSchema.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/JsonArrowSchema.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListNamespacesRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListNamespacesRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListNamespacesResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListNamespacesResponse.java
@@ -16,10 +16,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.LinkedHashSet;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableIndicesRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableIndicesRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableIndicesResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableIndicesResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableTagsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableTagsResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableVersionsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableVersionsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableVersionsResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTableVersionsResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTablesRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTablesRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTablesResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/ListTablesResponse.java
@@ -16,10 +16,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.LinkedHashSet;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MatchQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MatchQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MergeInsertIntoTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MergeInsertIntoTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MergeInsertIntoTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MergeInsertIntoTableResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MultiMatchQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/MultiMatchQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/NamespaceExistsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/NamespaceExistsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/NewColumnTransform.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/NewColumnTransform.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/Operator.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/Operator.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/PhraseQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/PhraseQuery.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequestFullTextQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequestFullTextQuery.java
@@ -16,10 +16,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequestVector.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/QueryTableRequestVector.java
@@ -16,10 +16,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RegisterTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RegisterTableRequest.java
@@ -17,10 +17,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RegisterTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RegisterTableResponse.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.HashMap;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RestoreTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RestoreTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RestoreTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/RestoreTableResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/SetPropertyMode.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/SetPropertyMode.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/StringFtsQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/StringFtsQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/StructuredFtsQuery.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/StructuredFtsQuery.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TableExistsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TableExistsRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TableVersion.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TableVersion.java
@@ -15,11 +15,10 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import org.springframework.format.annotation.DateTimeFormat;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
 
 import java.time.OffsetDateTime;
 import java.util.*;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TagContents.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TagContents.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TransactionStatus.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/TransactionStatus.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UnsetPropertyMode.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UnsetPropertyMode.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableResponse.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableResponse.java
@@ -15,9 +15,8 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.Objects;

--- a/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableTagRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/com/lancedb/lance/namespace/server/springboot/model/UpdateTableTagRequest.java
@@ -15,10 +15,9 @@ package com.lancedb.lance.namespace.server.springboot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import javax.annotation.Generated;
-import javax.validation.Valid;
-import javax.validation.constraints.*;
+import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -55,9 +55,11 @@
     </distributionManagement>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <lance-namespace.version>0.0.8</lance-namespace.version>
         <arrow.version>15.0.0</arrow.version>
-        <springboot.version>2.7.18</springboot.version>
+        <springboot.version>3.5.5</springboot.version>
         <junit-version>5.8.2</junit-version>
 
         <spotless.skip>false</spotless.skip>

--- a/java/springboot-server-pom.xml
+++ b/java/springboot-server-pom.xml
@@ -6,12 +6,9 @@
     <name>lance-namespace-springboot-server</name>
     <version>0.0.8</version>
     <properties>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>${java.version}</maven.compiler.source>
-        <maven.compiler.target>${java.version}</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <springdoc.version>1.6.14</springdoc.version>
-        <swagger-ui.version>5.3.1</swagger-ui.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <springdoc.version>2.6.0</springdoc.version>
+        <swagger-ui.version>5.17.14</swagger-ui.version>
     </properties>
     <parent>
         <groupId>com.lancedb</groupId>
@@ -33,7 +30,7 @@
           <!--SpringDoc dependencies -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
         <!-- @Nullable annotation -->


### PR DESCRIPTION
This PR moves `lance-namespace-springboot-server` to Spring Boot 3 as Spring Boot 2 has been EOL for a while. This requires JDK 17 to compile.