### PR TITLE
chore: move CONTRIBUTING.md to root level and update documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,14 @@
 # Contributing to Lance Namespace
 
+The Lance Namespace codebase is at [lancedb/lance-namespace](https://github.com/lancedb/lance-namespace).
+
 ## Repository structure
 
 | Component                    | Language | Path                                   | Description                                                               |
 |------------------------------|----------|----------------------------------------|---------------------------------------------------------------------------|
 | spec                         |          | docs/src/spec                          | Lance Namespace Specification                                             |
 | Rust Reqwest Client          | Rust     | rust/lance-namespace-reqwest-client    | Generated Rust reqwest client for Lance REST Namespace                    |
+| Rust Lance Namespace Core    | Rust     | rust/lance-namespace                   | Lance Namespace Rust Core SDK                                             |
 | Python UrlLib3 Client        | Python   | python/lance_namespace_urllib3_client  | Generated Python urllib3 client for Lance REST Namespace                  |
 | Python Lance Namespace Core  | Python   | python/lance_namespace                 | Lance Namespace Python Core SDK                                           |
 | Java Apache Client           | Java     | java/lance-namespace-apache-client     | Generated Java Apache HTTP client for Lance REST Namespace                |
@@ -74,8 +77,10 @@ make gen-docs
 
 ### Understanding the Build Process
 
-The contents in the `lance-namespace` repo are for the ease of contributors to edit and preview.
+The contents in `lance-namespace/docs` are for the ease of contributors to edit and preview.
 After code merge, the contents are added to the 
 [main Lance documentation](https://github.com/lancedb/lance/tree/main/docs) 
 during the Lance doc CI build time, and is presented in the Lance website under 
-[Apache Spark integration](https://lancedb.github.io/lance/format/namespace).
+[Lance Namespace Spec](https://lancedb.github.io/lance/format/namespace).
+
+The CONTRIBUTING.md document is auto-built to the [Lance Contributing Guide](https://lancedb.github.io/lance/community/contributing/) 

--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ It describes how a metadata service like Apache Hive MetaStore (HMS),
 Apache Gravitino, Unity Catalog, etc. should store and use Lance tables, 
 as well as how ML/AI tools and analytics compute engines should integrate with Lance tables.
 
-For more details, please visit the [documentation website](https://lancedb.github.io/lance-namespace).
+For more details, please visit the [documentation website](https://lancedb.github.io/lance/format/namespace).
+
+For development setup and contribution guidelines, please see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/src/.pages
+++ b/docs/src/.pages
@@ -3,4 +3,3 @@ nav:
   - Concepts: concepts.md
   - operations
   - impls
-  - Contributing: contributing.md


### PR DESCRIPTION
Moved `docs/src/contributing.md` to root-level `CONTRIBUTING.md` for better visibility and standard website build.