### PR TITLE
feat: more flexible override for Java REST client

### DIFF
--- a/java/lance-namespace-core/src/main/java/com/lancedb/lance/namespace/rest/RestNamespace.java
+++ b/java/lance-namespace-core/src/main/java/com/lancedb/lance/namespace/rest/RestNamespace.java
@@ -84,7 +84,7 @@ public class RestNamespace implements LanceNamespace {
 
   @Override
   public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
-    this.config = new RestNamespaceConfig(configProperties);
+    RestNamespaceConfig config = new RestNamespaceConfig(configProperties);
     // Note: RestNamespace doesn't use BufferAllocator, parameter ignored
 
     // Create ApiClient and set URI if provided
@@ -98,7 +98,11 @@ public class RestNamespace implements LanceNamespace {
     objectMapper.registerModule(new LanceNamespaceJacksonModule());
     client.setObjectMapper(objectMapper);
 
-    // Initialize API instances
+    initApiInstances(client, config);
+  }
+
+  protected void initApiInstances(ApiClient client, RestNamespaceConfig config) {
+    this.config = config;
     this.namespaceApi = new NamespaceApi(client);
     this.tableApi = new TableApi(client);
     this.transactionApi = new TransactionApi(client);


### PR DESCRIPTION
This PR makes a minor change to allow more flexible override of the Java REST client `initialize` function. We can use this to override `initialize` and create an `ApiClient` that uses a custom HTTP client with mTLS configuration set, for example. Because the member variables are set with `initApiInstances`, all of the existing methods can be used with the customized client.