### PR TITLE
chore(rust): fix version bump for reqwest client cargo override file

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -108,3 +108,8 @@ replace = 'version = "{new_version}"'
 filename = "rust/lance-namespace/Cargo.toml"
 search = 'version = "{current_version}"'
 replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "rust/reqwest-client.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'


### PR DESCRIPTION
## Summary
- Add rust/reqwest-client.toml to bumpversion configuration to ensure it gets updated along with other version files during releases

## Test plan
- [ ] Verify bumpversion configuration includes the new file
- [ ] Test version bumping works correctly with the reqwest-client.toml file

🤖 Generated with [Claude Code](https://claude.ai/code)